### PR TITLE
fix fileds df access

### DIFF
--- a/mindsdb_datasources/datasources/data_source.py
+++ b/mindsdb_datasources/datasources/data_source.py
@@ -191,7 +191,7 @@ class DataSource:
         try:
             return super().__getattribute__(attr)
         except AttributeError:
-            return getattr(self.df, attr)
+            return getattr(self._internal_df, attr)
 
     def __getitem__(self, key):
         """


### PR DESCRIPTION
There was a hard to find bug in the FileDS: if file can not be read (corrupted or no access, or etc), then on predictor learn start execution can fall to dead cycle.