### PR TITLE
Fix missining dependencies

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ include requirements_test.txt
 include optional_requirements_snowflake.txt
 include optional_requirements_extra_data_sources.txt
 include optional_requirements_scylla.txt
+include optional_requirements_cassandra.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include requirements.txt
 include requirements_test.txt
 include optional_requirements_snowflake.txt
 include optional_requirements_extra_data_sources.txt
+include optional_requirements_scylla.txt


### PR DESCRIPTION
Native installation fails because of missing optional_requirements_scylla in data sources.