### PR TITLE
Dremio datasource

### DIFF
--- a/mindsdb_datasources/__init__.py
+++ b/mindsdb_datasources/__init__.py
@@ -69,3 +69,8 @@ try:
 except ImportError:
     print("Cassandra Datasource is not available by default. If you wish to use it, please install mindsdb_native[cassandra]")
     CassandraDS = None
+
+try:
+    from mindsdb_datasources.datasources.dremio_ds import DremioDS
+except ImportError:
+    print("Dremio Datasource is not available by default. If you wish to use it, please install the Dremio ODBC Driver and pyodbc.")

--- a/mindsdb_datasources/__init__.py
+++ b/mindsdb_datasources/__init__.py
@@ -74,3 +74,4 @@ try:
     from mindsdb_datasources.datasources.dremio_ds import DremioDS
 except ImportError:
     print("Dremio Datasource is not available by default. If you wish to use it, please install the Dremio ODBC Driver and pyodbc.")
+    DremioDS = None

--- a/mindsdb_datasources/datasources/dremio_ds.py
+++ b/mindsdb_datasources/datasources/dremio_ds.py
@@ -1,0 +1,34 @@
+import pandas as pd
+import pyodbc
+from mindsdb_datasources.datasources.data_source import SQLDataSource
+
+
+class DremioDS(SQLDataSource):
+    def __init__(self, query, host, user, password, 
+                 driver='Dremio ODBC Driver 64-bit', port=31010):
+        super().__init__(query)
+        self.host = host
+        self.port = int(port)
+        self.driver = driver
+        self.user = user
+        self.password = password
+
+    def query(self, q):
+        con = pyodbc.connect(
+            f'Driver={self.driver};'
+            f'HOST={self.host};'
+            f'PORT={self.port};'
+            f'UID={self.user};'
+            f'PWD={self.password};'
+            'AuthenticationType=Plain;'
+            'ConnectionType=Direct;'
+        )
+
+        df = pd.read_sql(q, con=con)
+        con.close()
+
+        return df, self._make_colmap(df)
+
+    def name(self):
+        return 'Dremio - {}'.format(self._query)
+

--- a/tests/test_dremio_ds.py
+++ b/tests/test_dremio_ds.py
@@ -10,7 +10,7 @@ class TestSnowflake(unittest.TestCase):
 
         LIMIT = 100
         # Create the datasource
-        dreamio_ds = DremioDS(
+        dremio_ds = DremioDS(
             query=f'SELECT * FROM foo.bar LIMIT {LIMIT}',
             host=DB_CREDENTIALS['dremio']['host'],
             user=DB_CREDENTIALS['dremio']['port'],
@@ -18,5 +18,5 @@ class TestSnowflake(unittest.TestCase):
             account=DB_CREDENTIALS['dremio']['password'],
         )
 
-        assert len(dreamio_ds.df) == LIMIT
+        assert len(dremio_ds.df) == LIMIT
 

--- a/tests/test_dremio_ds.py
+++ b/tests/test_dremio_ds.py
@@ -1,0 +1,22 @@
+import os
+import unittest
+from common import DB_CREDENTIALS
+
+
+class TestSnowflake(unittest.TestCase):
+    def test_snowflake_ds(self):
+        print('RUNNING!')
+        from mindsdb_datasources import DremioDS
+
+        LIMIT = 100
+        # Create the datasource
+        dreamio_ds = DremioDS(
+            query=f'SELECT * FROM foo.bar LIMIT {LIMIT}',
+            host=DB_CREDENTIALS['dremio']['host'],
+            user=DB_CREDENTIALS['dremio']['port'],
+            password=DB_CREDENTIALS['dremio']['user'],
+            account=DB_CREDENTIALS['dremio']['password'],
+        )
+
+        assert len(dreamio_ds.df) == LIMIT
+

--- a/tests/test_dremio_ds.py
+++ b/tests/test_dremio_ds.py
@@ -3,19 +3,17 @@ import unittest
 from common import DB_CREDENTIALS
 
 
-class TestSnowflake(unittest.TestCase):
-    def test_snowflake_ds(self):
-        print('RUNNING!')
+class TestDremioDS(unittest.TestCase):
+    def test_dremio_ds(self):
         from mindsdb_datasources import DremioDS
 
         LIMIT = 100
-        # Create the datasource
+
         dremio_ds = DremioDS(
             query=f'SELECT * FROM foo.bar LIMIT {LIMIT}',
             host=DB_CREDENTIALS['dremio']['host'],
             user=DB_CREDENTIALS['dremio']['port'],
             password=DB_CREDENTIALS['dremio']['user'],
-            account=DB_CREDENTIALS['dremio']['password'],
         )
 
         assert len(dremio_ds.df) == LIMIT


### PR DESCRIPTION
Fixes mindsdb/mindsdb#1685

Initial implementation of the Dremio datasource.

What has been done:

1. Created and initial implementation of Dremio datasource based on the existing snowflake datasource and Dremio docs.
2. Added a very simple test boilerplate. This requires a Dremio instance with a database so for now I left the rest for discussion.

