### PR TITLE
Impala Datasource

### DIFF
--- a/mindsdb_datasources/__init__.py
+++ b/mindsdb_datasources/__init__.py
@@ -82,7 +82,7 @@ except ImportError:
     DremioDS = None
 
 try:
-    from mindsdb_datasources.datasources.bigquery_ds import BigQueryDS:
+    from mindsdb_datasources.datasources.bigquery_ds import BigQueryDS
 except ImportError:      
     print("BigQuery Datasource is not available by default. If you wish to use it, please install mindsdb_native[extra_data_sources]")
     BigQueryDS = None
@@ -90,5 +90,5 @@ except ImportError:
 try:
     from mindsdb_datasources.datasources.impala_ds import ImpalaDS
 except ImportError:
-    print("Impala Datasource is not available by default. If you wish to use it, please install mindsdb_native[extra_data_sources]")
+    print("Impala Datasource is not available by default. If you wish to use it, please install mindsdb[extra_data_sources]")
     ImpalaDS = None

--- a/mindsdb_datasources/__init__.py
+++ b/mindsdb_datasources/__init__.py
@@ -75,3 +75,9 @@ try:
 except ImportError:
     print("Timescale Datasource is not available by default. If you wish to use it, please install mindsdb_native[extra_data_sources]")
     TimescaleDS = None
+
+try:
+    from mindsdb_datasources.datasources.impala_ds import ImpalaDS
+except ImportError:
+    print("Impala Datasource is not available by default. If you wish to use it, please install mindsdb_native[extra_data_sources]")
+    ImpalaDS = None

--- a/mindsdb_datasources/datasources/impala_ds.py
+++ b/mindsdb_datasources/datasources/impala_ds.py
@@ -1,4 +1,5 @@
 import impala.dbapi
+from impala.util import as_pandas
 import pandas as pd
 
 from mindsdb_datasources.datasources.data_source import SQLDataSource
@@ -29,8 +30,10 @@ class ImpalaDS(SQLDataSource):
             password=self.password,
             database=self.database
         )
+        cur = con.cursor()
+        cur.execute(q)
 
-        df = pd.read_sql(q, con=con)
+        df = as_pandas(cur)
         con.close()
 
         return df, self._make_colmap(df)

--- a/mindsdb_datasources/datasources/impala_ds.py
+++ b/mindsdb_datasources/datasources/impala_ds.py
@@ -1,0 +1,39 @@
+import impala.dbapi
+import pandas as pd
+
+from mindsdb_datasources.datasources.data_source import SQLDataSource
+
+
+class ImpalaDS(SQLDataSource):
+    def __init__(self, query, host='localhost', port=21050, use_ssl=None,
+                 ca_cert=None, auth_mechanism='NOSASL', user=None,
+                 password=None, database=None):
+        super().__init__(query=query)
+        self.host = host
+        self.port = int(port)
+        self.use_ssl = use_ssl
+        self.ca_cert = ca_cert
+        self.auth_mechanism = auth_mechanism
+        self.user = user
+        self.password = password
+        self.database = database
+
+    def query(self, q):
+        con = impala.dbapi.connect(
+            host=self.host,
+            port=self.port,
+            use_ssl=self.use_ssl,
+            ca_cert=self.ca_cert,
+            auth_mechanism=self.auth_mechanism,
+            user=self.user,
+            password=self.password,
+            database=self.database
+        )
+
+        df = pd.read_sql(q, con=con)
+        con.close()
+
+        return df, self._make_colmap(df)
+
+    def name(self):
+        return 'Impala - {}'.format(self._query)

--- a/optional_requirements_extra_data_sources.txt
+++ b/optional_requirements_extra_data_sources.txt
@@ -3,3 +3,4 @@ PyAthena >= 2.0.0
 google-cloud-storage
 google-auth
 pymssql >= 2.1.4
+impyla >= 0.17.0

--- a/tests/test_impala_ds.py
+++ b/tests/test_impala_ds.py
@@ -1,5 +1,4 @@
 import unittest
-from mindsdb_native import F
 from common import DB_CREDENTIALS, break_dataset
 
 
@@ -28,5 +27,3 @@ class TestImpala(unittest.TestCase):
         impala_ds.df = break_dataset(impala_ds.df)
 
         assert len(impala_ds) == LIMIT
-
-        F.analyse_dataset(impala_ds)

--- a/tests/test_impala_ds.py
+++ b/tests/test_impala_ds.py
@@ -1,0 +1,32 @@
+import unittest
+from mindsdb_native import F
+from common import DB_CREDENTIALS, break_dataset
+
+
+class TestImpala(unittest.TestCase):
+    def setUp(self):
+        self.HOST = DB_CREDENTIALS['impala']['host']
+        self.PORT = int(DB_CREDENTIALS['impala']['port'])
+        self.DATABASE = 'impala'
+
+    def test_impala_ds(self):
+        from mindsdb_datasources import ImpalaDS
+
+        LIMIT = 100
+
+        impala_ds = ImpalaDS(
+            host=self.HOST,
+            port=self.PORT,
+            database=self.DATABASE,
+            query='SELECT * FROM {}.{} LIMIT {}'.format(
+                'test_data',
+                self.TABLE,
+                LIMIT
+            )
+        )
+
+        impala_ds.df = break_dataset(impala_ds.df)
+
+        assert len(impala_ds) == LIMIT
+
+        F.analyse_dataset(impala_ds)


### PR DESCRIPTION
Impala calls itself the native analytics database for Apache Hadoop. Impala allows to use data from diffrent backends in a hadoop environment such as files stored on HDFS, Apache Hbase or Apache Kudu. Very popular in my field of work so I thought it might be appropriate to add. More about Impala can be read [here](https://impala.apache.org/).

Changes:

1. Added an impala datasource based on the `impyla` library from Cloudera. (We could also connect through `pyodbc` and an ODBC driver for impala to limit dependencies`
2. Added impala datasource to init
3. Added a simple test boilerplate. This again needs to be checked because tests need a running Impala instance and as Impala uses Hadoop I'm not sure If it is viable to have a full cluster for this test. Something like the [Impala Quickstart](https://github.com/apache/kudu/tree/master/examples/quickstart/impala) could be used.

Again would be nice if this counted towards the goal as the other datasources 😄 