### PR TITLE
Phoenix datasource

### DIFF
--- a/mindsdb_datasources/__init__.py
+++ b/mindsdb_datasources/__init__.py
@@ -113,3 +113,9 @@ try:
 except ImportError:
     print("InfluxDB Datasource is not available by default. If you wish to use it, please install mindsdb_native[extra_data_sources]")
     InfluxDS = None
+
+try:
+    from mindsdb_datasources.datasources.phoenix_ds import PhoenixDS
+except ImportError:
+    print("Phoenix Datasource is not available by default. If you wish to use it, please install mindsdb[extra_datasources]")
+    PhoenixDS = None

--- a/mindsdb_datasources/datasources/phoenix_ds.py
+++ b/mindsdb_datasources/datasources/phoenix_ds.py
@@ -1,0 +1,34 @@
+import pandas as pd
+import phoenixdb
+
+from mindsdb_datasources.datasources.data_source import SQLDataSource
+
+
+class PhoenixDS(SQLDataSource):
+    def __init__(self, query, url, auth=None, authentication=None, user=None,
+                 password=None, verify=None):
+        super().__init__(query=query)
+        self.url = url
+        self.auth = auth
+        self.authentication = authentication
+        self.user = user
+        self.password = password
+        self.verify = verify
+
+    def query(self, q):
+        con = phoenixdb.connect(
+            url=self.url,
+            auth=self.auth,
+            authentication=self.authentication,
+            user=self.user,
+            password=self.password,
+            verify=self.verify
+        )
+
+        df = pd.read_sql(q, con=con)
+        con.close()
+
+        return df, self._make_colmap(df)
+
+    def name(self):
+        return 'Phoenix - {}'.format(self._query)

--- a/optional_requirements_extra_data_sources.txt
+++ b/optional_requirements_extra_data_sources.txt
@@ -5,3 +5,4 @@ google-auth
 pymssql >= 2.1.4
 google-cloud-bigquery >= 2.28.1
 trino >= 0.306.0
+phoenixdb >= 1.1.0

--- a/tests/test_phoenix_ds.py
+++ b/tests/test_phoenix_ds.py
@@ -1,0 +1,32 @@
+import unittest
+from common import DB_CREDENTIALS, break_dataset
+
+
+class TestPhoenix(unittest.TestCase):
+    def setUp(self):
+        self.URL = DB_CREDENTIALS['phoenix']['url']
+        self.AUTHENTICATION = 'BASIC'
+        self.USER = DB_CREDENTIALS['phoenix']['user']
+        self.PASSWORD = DB_CREDENTIALS['phoenix']['password']
+        self.TABLE = 'phoenix_test_table'
+
+    def test_phoenix_ds(self):
+        from mindsdb_datasources import PhoenixDS
+
+        LIMIT = 100
+
+        phoenix_ds = PhoenixDS(
+            url=self.URL,
+            authentication=self.AUTHENTICATION,
+            user=self.USER,
+            password=self.PASSWORD,
+            query='SELECT * FROM {}.{} LIMIT {}'.format(
+                'test_data',
+                self.TABLE,
+                LIMIT
+            )
+        )
+
+        phoenix_ds.df = break_dataset(phoenix_ds.df)
+
+        assert len(phoenix_ds) == LIMIT


### PR DESCRIPTION
Phoenix could be explained as an SQL frontend for the noSQL Hbase database, popular on Hadoop based systems. More information about [Phoenix](https://phoenix.apache.org/index.html).

This implementation is based on the python `phoenixdb` library which is now maintained by the Apache Phoenix team.

Changes:

1. Added an implementation of Phoenix datasource.
2. Added the phoenix datasource to init.
3. Created a simple test for the datasource.

An important thing about the `phoenixdb` library is the two authentication parameters: `auth` and `authentication`. The `auth` parameter accepts an requests-gssapi configuration (this is for kerberos authentication which is popular on Hadoop systems). The `authentication` parameter can be set to `BASIC` and `DIGEST`  and then an authentication using user and password can be achieved. 