### PR TITLE
Fixed HiveDS wrong module name

### DIFF
--- a/mindsdb_datasources/__init__.py
+++ b/mindsdb_datasources/__init__.py
@@ -108,7 +108,7 @@ except ImportError:
     print("Impala Datasource is not available by default. If you wish to use it, please install mindsdb[extra_data_sources]")
     ImpalaDS = None
 
-    from mindsdb_datasources.datasources.timescale_ds import HiveDS
+    from mindsdb_datasources.datasources.hive_ds import HiveDS
 except ImportError:
     print("Hive Datasource is not available by default. If you wish to use it, please install mindsdb[extra_data_sources]")
     HiveDS = None


### PR DESCRIPTION
Fixes: #53 

Changes:

- Changed module name from `timescale_ds` to `hive_ds`.